### PR TITLE
⚙️Chore: MySQL docker-compose.local.yml로 수정

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,9 +12,31 @@ services:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
 
   mysql:
+    container_name: mysql-container
+    image: mysql:8.0
+    ports:
+      - "3307:3306"
+    networks:
+      - app-network
+    env_file:
+      - .env
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: [ "CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u root -p$$MYSQL_ROOT_PASSWORD --silent" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     volumes:
       - ./mysql/data:/var/lib/mysql
-      - ./config/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+      - - ./config/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
 
   prometheus:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,30 +53,6 @@ services:
       timeout: 5s
       retries: 10
 
-  mysql:
-    container_name: mysql-container
-    image: mysql:8.0
-    ports:
-      - "3307:3306"
-    networks:
-      - app-network
-    env_file:
-      - .env
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      TZ: Asia/Seoul
-    command: >
-      --character-set-server=utf8mb4
-      --collation-server=utf8mb4_unicode_ci
-    healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u root -p$$MYSQL_ROOT_PASSWORD --silent"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-
   prometheus:
     container_name: prometheus-container
     image: prom/prometheus:latest


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #2

## 📝작업 내용
도커로 MySQL은 로컬에서만 실행하니 MySQL 관련된 부분은 `docker-compose.local.yml`에만 반영되도록 수정

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 개발 환경의 MySQL 서비스 구성을 개선하여 헬스 체크, 환경 변수, 초기화 스크립트 마운팅 등이 추가되었습니다.
  * 표준 Docker Compose 설정에서 MySQL 서비스가 제거되었습니다.

<sub>⚠️ Note: Your high-level summary instructions were not applied because this feature is currently available only to Pro plan users.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->