### PR TITLE
⚙️Chore: k6 도입 및 SecurityConfig에 actuator 엔드포인트 접속 허용으로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,7 @@ src/main/generated/
 grafana/
 
 # prometheus
-prometheus/data/
-prometheus/dev/
+prometheus/
 
 # rabbitmq
 rabbitmq/

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 services:
   redis:
     volumes:
@@ -10,7 +12,6 @@ services:
       - ./rabbitmq/data:/var/lib/rabbitmq
       - ./rabbitmq/log:/var/log/rabbitmq
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-
   mysql:
     container_name: mysql-container
     image: mysql:8.0
@@ -39,9 +40,18 @@ services:
       - ./config/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
 
   prometheus:
+    container_name: prometheus-container
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    networks:
+      - app-network
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
 
   grafana:
     volumes:
@@ -50,3 +60,19 @@ services:
   nginx:
     volumes:
       - ./config/local/nginx.conf:/etc/nginx/nginx.conf:ro
+
+  # k6 (로컬에서 AWS 서버 부하 테스트)
+  k6:
+    container_name: k6
+    image: grafana/k6:latest
+    networks:
+      - app-network
+    depends_on:
+      - prometheus
+    environment:
+      K6_OUT: experimental-prometheus-rw
+      K6_PROMETHEUS_RW_SERVER_URL: http://prometheus-container:9090/api/v1/write
+      TARGET_BASE_URL: http://${TARGET_BASE_URL}:8080
+    volumes:
+      - ./k6:/scripts:ro
+    entrypoint: ["k6"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 services:
   redis:
     container_name: redis-container
@@ -61,7 +63,7 @@ services:
     networks:
       - app-network
     command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--config.file=/etc/prometheus/prometheus.yml.template"
       - "--storage.tsdb.path=/prometheus"
 
   grafana:

--- a/k6/baseline.js
+++ b/k6/baseline.js
@@ -1,0 +1,30 @@
+import { get } from "./common.js";
+
+export const options = {
+    scenarios: {
+        warmup: {
+            executor: "constant-arrival-rate",
+            rate: 50,
+            timeUnit: "1s",
+            duration: "10m",
+            preAllocatedVUs: 200,
+            maxVUs: 500,
+        },
+        measure: {
+            executor: "constant-arrival-rate",
+            rate: 100,
+            timeUnit: "1s",
+            duration: "15m",
+            preAllocatedVUs: 300,
+            maxVUs: 800,
+            startTime: "10m",
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+export default function () {
+    get("/api/health");
+}

--- a/k6/common.js
+++ b/k6/common.js
@@ -1,0 +1,26 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+export function baseUrl() {
+    const url = __ENV.TARGET_BASE_URL;
+    if (!url) throw new Error("TARGET_BASE_URL is required. e.g. http://<ec2-public-dns>:8080");
+    return url.replace(/\/$/, "");
+}
+
+export function headers() {
+    const h = { "Content-Type": "application/json" };
+    if (__ENV.API_TOKEN) h["Authorization"] = `Bearer ${__ENV.API_TOKEN}`;
+    return h;
+}
+
+export function get(path) {
+    const res = http.get(`${baseUrl()}${path}`, { headers: headers() });
+    check(res, {
+        "status is 2xx/3xx": (r) => r.status >= 200 && r.status < 400,
+    });
+    return res;
+}
+
+export function pause(sec = 1) {
+    sleep(sec);
+}

--- a/k6/endurance.js
+++ b/k6/endurance.js
@@ -1,0 +1,21 @@
+import { get } from "./common.js";
+
+export const options = {
+    scenarios: {
+        soak: {
+            executor: "constant-arrival-rate",
+            rate: 80,
+            timeUnit: "1s",
+            duration: "2h",
+            preAllocatedVUs: 400,
+            maxVUs: 1500,
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+export default function () {
+    get("/api/health");
+}

--- a/k6/load.js
+++ b/k6/load.js
@@ -1,0 +1,30 @@
+import { get } from "./common.js";
+
+export const options = {
+    scenarios: {
+        warmup: {
+            executor: "constant-arrival-rate",
+            rate: 100,
+            timeUnit: "1s",
+            duration: "10m",
+            preAllocatedVUs: 300,
+            maxVUs: 800,
+        },
+        measure: {
+            executor: "constant-arrival-rate",
+            rate: 100,
+            timeUnit: "1s",
+            duration: "20m",
+            preAllocatedVUs: 300,
+            maxVUs: 800,
+            startTime: "10m",
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+export default function () {
+    get("/api/health");
+}

--- a/k6/smoke.js
+++ b/k6/smoke.js
@@ -1,0 +1,14 @@
+import { get, pause } from "./common.js";
+
+export const options = {
+    vus: 5,
+    duration: "5m",
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+export default function () {
+    get("/api/health");
+    pause(1);
+}

--- a/k6/stress.js
+++ b/k6/stress.js
@@ -1,0 +1,26 @@
+import { get } from "./common.js";
+
+export const options = {
+    scenarios: {
+        stress: {
+            executor: "ramping-arrival-rate",
+            timeUnit: "1s",
+            preAllocatedVUs: 400,
+            maxVUs: 1500,
+            stages: [
+                { target: 100, duration: "5m" },
+                { target: 150, duration: "5m" },
+                { target: 200, duration: "5m" },
+                { target: 250, duration: "5m" },
+                { target: 300, duration: "5m" },
+            ],
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.03"],
+    },
+};
+
+export default function () {
+    get("/api/health");
+}

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,20 +1,22 @@
 global:
   scrape_interval: 5s
+  evaluation_interval: 5s
 
 scrape_configs:
-  - job_name: "prometheus"
+  - job_name: prometheus
     static_configs:
       - targets: ["prometheus-container:9090"]
 
-  - job_name: "redis"
+  - job_name: redis_exporter
     static_configs:
-      - targets: ["redis-exporter-container:9121"]
+      - targets: [":9121"]
 
-  - job_name: "rabbitmq"
+  - job_name: rabbitmq
     static_configs:
-      - targets: ["rabbitmq-container:15692"]  # rabbitmq_prometheus plugin endpoint
+      - targets: [":15692"]
 
-  - job_name: "spring-boot"
-    metrics_path: "/actuator/prometheus"
+  - job_name: aws_spring
+    metrics_path: /actuator/prometheus
+    scheme: http
     static_configs:
-      - targets: ["host.docker.internal:8081"]  # 도커 외부에서 실행 중인 Spring Boot
+      - targets: [":8080"]

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
                                 "/api/expert/list", "/api/expert/{expert-id}",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",
                                 "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments",
-                                "/ws-stomp/**", "/test", "/**").permitAll()
+                                "/ws-stomp/**", "/test", "/actuator/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #14 

## 📝작업 내용
- k6 도입
  - `docker-compose.yml`,  `docker-compose.local.yml`에 해당 설정 추가
  - 추후 관련 스크립트 파일 수정
- `SecurityConfig`에 actuator 엔드포인트 접속 허용으로 수정
  - 그라파나 모니터링 시 엔드포인트 접속 허용 필요 
  - `application.yml` 파일에서 actuator 관련 엔드포인트 설정도 함께 열어야 함

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Prometheus 모니터링 서비스 추가
  * k6 기반 성능 테스트 스크립트 추가 (스모크, 로드, 스트레스, 베이스라인, 지구력 테스트)

* **보안**
  * 공개 API 접근을 특정 엔드포인트로만 제한하여 보안 강화

<sub>⚠️ Note: Your high-level summary instructions were not applied because this feature is currently available only to Pro plan users.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->