### PR TITLE
✨Feat: 홈 커뮤니티 게시글 조회 Redis 캐시 도입 및 좋아요 이벤트 기반 캐시 무효화 적용

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,49 +1,55 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: ko-KR
+
 reviews:
   profile: assertive
-  request_changes_workflow: true
-  high_level_summary_in_walkthrough: true
-  fail_commit_status: true
-  auto_apply_labels: true
-  auto_assign_reviewers: true
+
+  high_level_summary: true
+  high_level_summary_instructions: |
+    PR 변경 사항을 한국어로 간결하게 요약해 주세요.
+    성능, 구조, 안정성 관점의 핵심 변경점을 중심으로 설명해 주세요.
+
   path_instructions:
-    - path: '**/*'
+    - path: "**/*.java"
       instructions: |
-        다음 기준을 기반으로 Spring Boot 프로젝트 코드를 검토해 주세요.
+        아래 기준에 따라 Java 코드를 줄 단위로 상세히 리뷰해 주세요.
+        문제가 있는 코드 라인에는 직접 코멘트를 남겨 주세요.
 
         1. 예외 처리
-           - @ControllerAdvice / @ExceptionHandler를 통한 글로벌 예외 처리 여부
-           - RuntimeException의 과도한 사용 여부
-           - 에러 메시지 또는 로그에 민감 정보(비밀번호, 토큰 등)가 노출되지 않는지
+           - @ControllerAdvice / @ExceptionHandler 사용 여부
+           - RuntimeException 남용 여부
+           - 로그에 민감 정보 노출 여부
 
         2. 코드 품질 & 구조
-           - 단일 책임 원칙(SRP) 준수 여부
-           - 중복 코드 존재 여부
-           - DTO ↔ Entity 변환 구조가 계층 분리에 맞게 구현되어 있는지
-           - Service 계층이 과도하게 비대해지지 않았는지
+           - 단일 책임 원칙(SRP) 위반
+           - 중복 코드
+           - DTO ↔ Entity 변환 책임 위치
+           - Service 계층 비대화 여부
 
         3. Spring Web & REST API
-           - HTTP 상태코드 사용이 표준에 맞는지
-           - 컨트롤러에 비즈니스 로직이 존재하지 않는지
-           - Request/Response DTO 설계가 적절한지
+           - HTTP 상태 코드 적절성
+           - 컨트롤러 비즈니스 로직 포함 여부
 
         4. JPA & Query 성능
-           - 즉시 로딩(EAGER) 남용 여부
-           - N+1 문제 가능성 여부
-           - 불필요한 쿼리 발생 여부
-           - fetch join 또는 batch size 사용이 가능한 부분은 없는지
+           - EAGER 로딩 남용
+           - N+1 문제 가능성
+           - fetch join / batch size 개선 포인트
 
-        5. 트랜잭션 관리
-           - @Transactional 위치가 올바른지 (Service 계층 중심)
-           - readOnly = true 옵션이 조회성 트랜잭션에 적용되어 있는지
-           - 트랜잭션 범위가 지나치게 넓지는 않은지
+        5. 트랜잭션
+           - @Transactional 위치
+           - readOnly 적용 여부
+           - 트랜잭션 범위 적절성
 
         6. 보안
-           - 비밀번호/액세스 토큰/API Key 등 민감 정보가 로그로 출력되지 않는지
+           - 민감 정보 로그 출력 여부
            - @Valid / Bean Validation 사용 여부
-           - 인증/인가 우회 위험이 없는지
+           - 인증/인가 우회 가능성
 
-        위 모든 항목을 고려해, 코드 개선점과 구체적인 수정 방법을 제안해 주세요.
   auto_review:
+    enabled: true
     drafts: true
+
+  request_changes_workflow: true
+  auto_apply_labels: true
+  auto_assign_reviewers: true
+  fail_commit_status: true

--- a/src/main/java/com/backend/farmon/config/CacheConfig.java
+++ b/src/main/java/com/backend/farmon/config/CacheConfig.java
@@ -1,0 +1,8 @@
+package com.backend.farmon.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {}

--- a/src/main/java/com/backend/farmon/config/RedisConfig.java
+++ b/src/main/java/com/backend/farmon/config/RedisConfig.java
@@ -80,18 +80,15 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    //레디스 캐시
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext
-                        .SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext
-                        .SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+                .entryTtl(java.time.Duration.ofSeconds(60))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
-        return RedisCacheManager
-                .RedisCacheManagerBuilder
-                .fromConnectionFactory(redisConnectionFactory)
+        return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
     }

--- a/src/main/java/com/backend/farmon/service/LikeService/LikeServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/LikeService/LikeServiceImpl.java
@@ -1,18 +1,22 @@
 package com.backend.farmon.service.LikeService;
 
-
 import com.backend.farmon.apiPayload.code.status.ErrorStatus;
 import com.backend.farmon.apiPayload.exception.GeneralException;
 import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.domain.LikeCount;
 import com.backend.farmon.domain.Post;
 import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.post.PostType;
 import com.backend.farmon.repository.LikeCountRepository.LikeCountRepository;
 import com.backend.farmon.repository.PostRepository.PostRepository;
 import com.backend.farmon.repository.UserRepository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -25,25 +29,64 @@ public class LikeServiceImpl {
     private final LikeCountRepository likeCountRepository;
     private final UserAuthorizationUtil userAuthorizationUtil;
 
+    // 추가: 캐시 수동 evict를 위한 주입
+    private final CacheManager cacheManager;
+
+    // 캐시 무효화 (커밋 이후 실행)
+    private void evictHomeCommunityCacheAfterCommit(PostType postType) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            evictHomeCommunityCacheNow(postType);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                evictHomeCommunityCacheNow(postType);
+            }
+        });
+    }
+
+    // 캐시 무효화 (즉시 실행)
+    private void evictHomeCommunityCacheNow(PostType postType) {
+        Cache cache = cacheManager.getCache("home:community");
+        if (cache == null) return;
+
+        // POPULAR은 항상 무효화
+        cache.evict("category:POPULAR");
+
+        // default 케이스(특정 타입)만 무효화하고 싶다면 ALL/POPULAR은 제외
+        if (postType != null && postType != PostType.ALL && postType != PostType.POPULAR) {
+            cache.evict("category:" + postType.name());
+        }
+    }
+
+    private void validateRole() throws IllegalAccessException {
+        String currentUserRole = userAuthorizationUtil.getCurrentUserRole();
+        if (!"FARMER".equals(currentUserRole) && !"EXPERT".equals(currentUserRole)) {
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Post getOriginalPost(Post post) {
+        if (post.getOriginalPostId() == null) return post;
+
+        return postRepository.findById(post.getOriginalPostId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    }
 
     // 좋아요 추가
     @Transactional
     public void postLikeUp(Long userId, Long postId) throws IllegalAccessException {
-        String currentUserRole = userAuthorizationUtil.getCurrentUserRole();
+        validateRole();
 
-        if (!"FARMER".equals(currentUserRole) && !"EXPERT".equals(currentUserRole)) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED_ACCESS);
-        }
-        
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
-        // 원본 게시물 찾기 (originalPostId가 null인 게시물)
 
-        Post originalPost = post.getOriginalPostId() == null ? post
-                : postRepository.findById(post.getOriginalPostId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        Post originalPost = getOriginalPost(post);
 
         // originalPostId가 같은 모든 게시물 가져오기
         List<Post> relatedPosts = postRepository.findAllByOriginalPostId(originalPost.getId());
@@ -62,7 +105,7 @@ public class LikeServiceImpl {
         // 원본 게시물 기준으로 좋아요 저장
         LikeCount likeCount = LikeCount.builder()
                 .user(user)
-                .post(originalPost) // 원본 게시물로 저장
+                .post(originalPost)
                 .build();
         likeCountRepository.save(likeCount);
 
@@ -73,28 +116,24 @@ public class LikeServiceImpl {
 
         postRepository.saveAll(relatedPosts);
         postRepository.flush();
+
+        // 커밋 이후 캐시 무효화 (POPULAR + 해당 타입)
+        PostType postType = originalPost.getBoard().getPostType();
+        evictHomeCommunityCacheAfterCommit(postType);
     }
 
     // 좋아요 감소
     @Transactional
     public void postLikeDown(Long userId, Long postId) throws IllegalAccessException {
-
-        String currentUserRole = userAuthorizationUtil.getCurrentUserRole();
-
-        if (!"FARMER".equals(currentUserRole) && !"EXPERT".equals(currentUserRole)) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED_ACCESS);
-        }
+        validateRole();
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
 
-
-        // 원본 게시물 찾기
-        Post originalPost = post.getOriginalPostId() == null ? post
-                : postRepository.findById(post.getOriginalPostId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        Post originalPost = getOriginalPost(post);
 
         // 좋아요 찾기 (원본 게시물 기준)
         LikeCount like = likeCountRepository.findByUserIdAndPostId(userId, originalPost.getId());
@@ -116,15 +155,14 @@ public class LikeServiceImpl {
         postRepository.saveAll(relatedPosts);
         postRepository.flush();
 
+        // 커밋 이후 캐시 무효화 (POPULAR + 해당 타입)
+        PostType postType = originalPost.getBoard().getPostType();
+        evictHomeCommunityCacheAfterCommit(postType);
     }
 
-
     // 좋아요 개수 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public int getLikeCount(Long postId) {
         return postRepository.getLikeCount(postId);
     }
-
-
-
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
@@ -15,14 +15,12 @@ import com.backend.farmon.dto.post.PostPagingResponseDTO;
 import com.backend.farmon.dto.post.PostResponseDTO;
 import com.backend.farmon.dto.post.PostType;
 import com.backend.farmon.dto.post.PostWithAnswersResponseDTO;
-import com.backend.farmon.repository.AnswerRepository.AnswerRepository;
 import com.backend.farmon.repository.BoardRepository.BoardRepository;
-import com.backend.farmon.repository.CommentRepository.CommentRepository;
-import com.backend.farmon.repository.LikeCountRepository.LikeCountRepository;
 import com.backend.farmon.repository.PostRepository.PostRepository;
 import com.backend.farmon.service.AWS.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -48,6 +46,11 @@ public class PostQueryServiceImpl implements PostQueryService {
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     // 인기, 전체, QNA, 전문가 칼럼
     @Override
+    @Cacheable(
+            cacheNames = "home:community",
+            key = "'category:' + #category.name()",
+            unless = "#result == null"
+    )
     public HomeResponse.PostListDTO findHomePostsByCategory(PostType category) {
 
         List<HomePostRow> rows = switch (category) {
@@ -55,6 +58,8 @@ public class PostQueryServiceImpl implements PostQueryService {
             case POPULAR -> postRepository.findTopPostsByLikesWithCounts(POST_LIMIT);
             default -> postRepository.findTopPostsByPostTypeWithCounts(category, POST_LIMIT);
         };
+
+        log.info("[findHomePostsByCategory] DB query executed. category={}", category);
 
         return HomeConverter.toPostListDTO(rows);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

>  - #18 
> - #14 

## 📝 작업 내용
홈 커뮤니티 조회 성능 개선을 위해 Redis 캐시를 도입하고,  
좋아요 변경 시 필요한 범위에 한해 캐시를 무효화하도록 캐시 전략을 정비.

- 홈 커뮤니티 조회 로직에 Redis 기반 캐시 적용
  - cache name: `home:community`
  - cache key: `category:{PostType}`
  - TTL 60초 적용
- 카테고리별 홈 게시글 조회 결과를 캐시하여 반복 조회 시 DB 접근 최소화
- 좋아요 추가/삭제 이벤트 발생 시 캐시 무효화 로직 추가
  - 트랜잭션 커밋 이후(afterCommit)에만 캐시 무효화 수행
  - `POPULAR` 카테고리는 항상 캐시 무효화
  - QNA / EXPERT_COLUMN 등 타입 카테고리는 해당 타입에 한해 선택적으로 무효화
  - `ALL` 카테고리는 TTL 기반 갱신 정책 유지
- 홈 조회(@Cacheable) 로직 및 캐시 키 구조는 변경 없이 유지

이를 통해 홈 조회 트래픽은 캐시로 흡수하면서도,  
인기/타입 탭은 좋아요 변경 사항이 비교적 빠르게 반영되도록 개선.

서버에 배포 후, 해당 리팩토링 코드로 다시 부하테스트 후 성능 비교 예정

### 스크린샷 (선택)
캐시된 데이터가 없는 경우
<img width="1072" height="693" alt="스크린샷 2026-01-07 오후 11 04 57" src="https://github.com/user-attachments/assets/821e95f5-85d4-417d-82f7-9fb25502d242" />
<img width="1303" height="269" alt="스크린샷 2026-01-07 오후 11 04 43" src="https://github.com/user-attachments/assets/036c8b67-6ae3-4ce8-89bb-977884b2e558" />

&nbsp;
캐시된 데이터가 있는 경우
<img width="1293" height="100" alt="스크린샷 2026-01-07 오후 11 05 49" src="https://github.com/user-attachments/assets/f0a63f00-0d87-4dd5-9b8c-151d4d8942ac" />

&nbsp;
좋아요가 반영된 경우
<img width="1290" height="136" alt="스크린샷 2026-01-07 오후 11 07 11" src="https://github.com/user-attachments/assets/60cfcdb5-536f-436b-bd1d-e679b592365d" />
<img width="1309" height="77" alt="스크린샷 2026-01-07 오후 11 07 37" src="https://github.com/user-attachments/assets/4ba247b6-fa03-4126-9f57-454d11efbc03" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 성능
  - Redis 기반 캐시 도입으로 홈 커뮤니티 조회 성능 개선
    - 캐시명: "home:community", 키: "category:{PostType}", TTL: 60초
    - PostQueryServiceImpl.findHomePostsByCategory에 @Cacheable 적용(unless="#result == null")로 반복 조회 시 DB 접근 최소화

- 구조
  - 캐시 설정 추가
    - CacheConfig(@EnableCaching) 추가
    - RedisConfig에서 RedisCacheManager 구성: 60초 TTL, 키는 StringRedisSerializer, 값은 GenericJackson2JsonRedisSerializer, null 값 캐싱 비활성화
  - 좋아요 흐름에 캐시 연동
    - LikeServiceImpl에 CacheManager 주입 및 캐시 무효화 유틸(즉시/트랜잭션 커밋 이후) 추가
    - 원본 게시글 조회(getOriginalPost), 역할 검증(validateRole) 등 내부 헬퍼 도입
    - 중복 좋아요 방지, 자기 좋아요 방지 로직과 원본 기반 LikeCount 저장/삭제 로직 통합

- 안정성
  - 캐시 일관성 보장: 좋아요 추가/삭제시 트랜잭션 커밋 이후(afterCommit)에만 캐시 무효화 실행하여 DB/캐시 불일치 최소화
  - 무효화 전략
    - POPULAR 카테고리: 항상 무효화
    - 타입별 카테고리(QNA, EXPERT_COLUMN 등): 해당 타입에 한해 선택적 무효화
    - ALL 카테고리: TTL(60s)에 의한 자연 갱신 정책 유지
  - 기존 홈 조회의 캐시 키 구조 및 @Cacheable 호출 방식은 변경하지 않아 호환성 유지

- 기타 변경/정리
  - findHomePostsByCategory에 DB 쿼리 로그 추가
  - 불필요한 리포지토리 임포트 제거

요약: Redis 캐시(60s TTL)로 홈 조회 부하를 흡수하면서, 좋아요 이벤트는 트랜잭션 커밋 기반의 선택적 캐시 무효화로 반영 지연을 최소화하고 데이터 일관성을 확보하도록 설계됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->